### PR TITLE
Include Friendship in the Summary Screen

### DIFF
--- a/include/bw_summary_screen.h
+++ b/include/bw_summary_screen.h
@@ -21,7 +21,7 @@
 #define BW_SUMMARY_CATEGORY_ICONS                   TRUE                // determines whether category (split) icons are shown or not
 #define BW_SUMMARY_IV_EV_DISPLAY                    BW_IV_EV_GRADED     // determines how to show IVs and EVs
 #define BW_SUMMARY_DECAP                            TRUE                // indicates if summary screen-specific strings should be decapitalized
-#define BW_SUMMARY_SHOW_FRIENDSHIP                  FALSE               // show a heart that fills up to indicate friendship value
+#define BW_SUMMARY_SHOW_FRIENDSHIP                  TRUE                // show a heart that fills up to indicate friendship value
 #define BW_SUMMARY_BW_STATUS_ICONS                  TRUE                // use Gen 5 style status icons instead of the default ones.
 #define BW_SUMMARY_BW_TYPE_ICONS                    TRUE                // use Gen 5 style type icons instead of the default ones.
                                                                         // out of the box the vanilla icons don't fit well, this is mostly a compatibility


### PR DESCRIPTION
A simple PR that enables the BW Summary Screen config option to display friendship in the summary. All of the functionality is already built in, this PR just enables it.